### PR TITLE
Scripted http schema manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,6 @@ If you need to use more complex logic like fetch bearer token using client secre
   },
 ```
 
-Or just using shorter syntax:
-
-```json
-  "schema": "my-graphql-config.js",
-```
-
 Your script have to return valid `RequestSetup` or `Promise<RequestSetup>` object:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ You can pass URL and custom HTTP headers. It's useful to use an existing GraphQL
   },
 ```
 
-If you need to use more complex logic like fetch bearer token using client secret then you can build your configuration using js script. First, you need to setup your configuration like below:
+If you need to use more complex logic like fetch bearer token using client secret then you can build your http schema configuration using javascript. First, you need to setup your plugin configuration like below:
 
 ```json
   "schema": {
@@ -193,9 +193,18 @@ Or just using shorter syntax:
   "schema": "my-graphql-config.js",
 ```
 
-Then in your `my-graphql-config.js` file export function that returns promise or result. Example:
+Your script have to return valid `RequestSetup` or `Promise<RequestSetup>` object:
+
+```ts
+url: string;
+method?: string; // default to 'POST'
+headers?: { [key: string]: string };
+```
+
+Example how configuration script may look like:
 
 ```js
+// my-graphql-config.js
 const fetch = require('node-fetch');
 
 module.exports = projectRootPath =>

--- a/src/schema-manager/http-schema-manager.ts
+++ b/src/schema-manager/http-schema-manager.ts
@@ -2,10 +2,6 @@ import { SchemaManager } from './schema-manager';
 import { SchemaManagerHost } from './types';
 import { requestIntrospectionQuery, RequestSetup } from './request-introspection-query';
 
-function isRequestSetup(conf: any): conf is RequestSetup {
-  return !!conf?.url;
-}
-
 export class HttpSchemaManager extends SchemaManager {
   private _schema: any = null;
 
@@ -16,6 +12,8 @@ export class HttpSchemaManager extends SchemaManager {
   protected async _getOptions(): Promise<RequestSetup | null> {
     return this._options;
   }
+
+  protected _fetchErrorOcurred(): void {}
 
   getBaseSchema() {
     return this._schema;
@@ -46,8 +44,8 @@ export class HttpSchemaManager extends SchemaManager {
         return;
       }
 
-      if (!isRequestSetup(options)) {
-        this.log(`Options is not RequestSetup object: ${JSON.stringify(options, null, 2)}`);
+      if (options === null) {
+        this.log(`Options cannot be null`);
         setTimeout(makeRequest, backoff * 2.0);
         return;
       }
@@ -67,6 +65,7 @@ export class HttpSchemaManager extends SchemaManager {
         this.log(`Fail to fetch schema data from ${options.url} via:`);
         this.log(`${JSON.stringify(reason, null, 2)}`);
 
+        this._fetchErrorOcurred();
         setTimeout(makeRequest, backoff * 2.0);
       }
     };

--- a/src/schema-manager/request-introspection-query.ts
+++ b/src/schema-manager/request-introspection-query.ts
@@ -1,0 +1,78 @@
+import { GraphQLSchema, buildClientSchema, introspectionQuery } from 'graphql';
+import { parse } from 'url';
+import Http from 'http';
+import Https from 'https';
+
+const INTROSPECTION_QUERY_BODY = JSON.stringify({
+  query: introspectionQuery,
+});
+
+const INTROSPECTION_QUERY_LENGTH = Buffer.byteLength(INTROSPECTION_QUERY_BODY);
+
+export interface RequestSetup {
+  url: string;
+  method?: 'POST';
+  headers?: { [key: string]: string };
+}
+
+export function isRequestSetup(requestSetup: RequestSetup | any): requestSetup is RequestSetup {
+  const availablePropertyNames = ['url', 'method', 'headers'];
+  let hasUrlProperty = false;
+
+  for (const property in requestSetup) {
+    if (!availablePropertyNames.includes(property)) {
+      return false;
+    }
+
+    if (property === 'url') {
+      hasUrlProperty = true;
+    }
+  }
+
+  return hasUrlProperty;
+}
+
+export function requestIntrospectionQuery(options: RequestSetup) {
+  const headers: { [key: string]: string | number } = {
+    'Content-Type': 'application/json',
+    'Content-Length': INTROSPECTION_QUERY_LENGTH,
+    'User-Agent': 'ts-graphql-plugin',
+    ...options.headers,
+  };
+
+  return new Promise<GraphQLSchema>((resolve, reject) => {
+    const uri = parse(options.url);
+
+    const { method } = options;
+    const { hostname, protocol, path } = uri;
+    const port = uri.port && Number.parseInt(uri.port, 10);
+    const reqParam = { hostname, protocol, path, port, headers, method };
+
+    const requester = protocol === 'https:' ? Https.request : Http.request;
+    let body = '';
+
+    const req = requester(reqParam, res => {
+      res.on('data', chunk => (body += chunk));
+      res.on('end', () => {
+        if (!res.statusCode || res.statusCode < 200 || res.statusCode > 300) {
+          reject({
+            statusCode: res.statusCode,
+            body,
+          });
+        } else {
+          let result: any;
+          try {
+            result = JSON.parse(body);
+            resolve(buildClientSchema(result.data));
+          } catch (e) {
+            reject(e);
+          }
+        }
+      });
+    });
+
+    req.on('error', reason => reject(reason));
+    req.write(INTROSPECTION_QUERY_BODY);
+    req.end();
+  });
+}

--- a/src/schema-manager/request-introspection-query.ts
+++ b/src/schema-manager/request-introspection-query.ts
@@ -17,19 +17,14 @@ export interface RequestSetup {
 
 export function isRequestSetup(requestSetup: RequestSetup | any): requestSetup is RequestSetup {
   const availablePropertyNames = ['url', 'method', 'headers'];
-  let hasUrlProperty = false;
 
   for (const property in requestSetup) {
     if (!availablePropertyNames.includes(property)) {
       return false;
     }
-
-    if (property === 'url') {
-      hasUrlProperty = true;
-    }
   }
 
-  return hasUrlProperty;
+  return !!requestSetup.url;
 }
 
 export function requestIntrospectionQuery(options: RequestSetup) {

--- a/src/schema-manager/request-introspection-query.ts
+++ b/src/schema-manager/request-introspection-query.ts
@@ -1,10 +1,10 @@
-import { GraphQLSchema, buildClientSchema, introspectionQuery } from 'graphql';
+import { GraphQLSchema, buildClientSchema, getIntrospectionQuery } from 'graphql';
 import { parse } from 'url';
 import Http from 'http';
 import Https from 'https';
 
 const INTROSPECTION_QUERY_BODY = JSON.stringify({
-  query: introspectionQuery,
+  query: getIntrospectionQuery(),
 });
 
 const INTROSPECTION_QUERY_LENGTH = Buffer.byteLength(INTROSPECTION_QUERY_BODY);

--- a/src/schema-manager/request-introspection-query.ts
+++ b/src/schema-manager/request-introspection-query.ts
@@ -11,7 +11,7 @@ const INTROSPECTION_QUERY_LENGTH = Buffer.byteLength(INTROSPECTION_QUERY_BODY);
 
 export interface RequestSetup {
   url: string;
-  method?: 'POST';
+  method?: string;
   headers?: { [key: string]: string };
 }
 

--- a/src/schema-manager/schema-manager-factory.test.ts
+++ b/src/schema-manager/schema-manager-factory.test.ts
@@ -3,49 +3,49 @@ import { HttpSchemaManager } from './http-schema-manager';
 import { FileSchemaManager } from './file-schema-manager';
 import { createTestingSchemaManagerHost } from './testing/testing-schema-manager-host';
 
-describe('SchemaManagerFactory', () => {
+describe(SchemaManagerFactory, () => {
   it('should return HttpSchemaManager from http url string', () => {
-    const facotry = new SchemaManagerFactory(
+    const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: 'http://localhost',
       }),
     );
-    const actual = facotry.create();
+    const actual = factory.create();
     expect(actual instanceof HttpSchemaManager).toBeTruthy();
   });
 
   it('should return HttpSchemaManager from https url string', () => {
-    const facotry = new SchemaManagerFactory(
+    const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: 'https://localhost',
       }),
     );
-    const actual = facotry.create();
+    const actual = factory.create();
     expect(actual instanceof HttpSchemaManager).toBeTruthy();
   });
 
   it('should return FileSchemaManager from file schema string', () => {
-    const facotry = new SchemaManagerFactory(
+    const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: 'file:///tmp/s.json',
       }),
     );
-    const actual = facotry.create();
+    const actual = factory.create();
     expect(actual instanceof FileSchemaManager).toBeTruthy();
   });
 
   it('should return FileSchemaManager from no schema string', () => {
-    const facotry = new SchemaManagerFactory(
+    const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: '/tmp/s.json',
       }),
     );
-    const actual = facotry.create();
+    const actual = factory.create();
     expect(actual instanceof FileSchemaManager).toBeTruthy();
   });
 
   it('should return HttpSchemaManager from http object', () => {
-    const facotry = new SchemaManagerFactory(
+    const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: {
           http: {
@@ -54,12 +54,12 @@ describe('SchemaManagerFactory', () => {
         },
       }),
     );
-    const actual = facotry.create();
+    const actual = factory.create();
     expect(actual instanceof HttpSchemaManager).toBeTruthy();
   });
 
   it('should return FileSchemaManager from file object', () => {
-    const facotry = new SchemaManagerFactory(
+    const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: {
           file: {
@@ -68,7 +68,7 @@ describe('SchemaManagerFactory', () => {
         },
       }),
     );
-    const actual = facotry.create();
+    const actual = factory.create();
     expect(actual instanceof FileSchemaManager).toBeTruthy();
   });
 });

--- a/src/schema-manager/schema-manager-factory.test.ts
+++ b/src/schema-manager/schema-manager-factory.test.ts
@@ -2,6 +2,7 @@ import { SchemaManagerFactory } from './schema-manager-factory';
 import { HttpSchemaManager } from './http-schema-manager';
 import { FileSchemaManager } from './file-schema-manager';
 import { createTestingSchemaManagerHost } from './testing/testing-schema-manager-host';
+import { ScriptedHttpSchemaManager } from './scripted-http-schema-manager';
 
 describe(SchemaManagerFactory, () => {
   it('should return HttpSchemaManager from http url string', () => {
@@ -44,7 +45,7 @@ describe(SchemaManagerFactory, () => {
     expect(actual instanceof FileSchemaManager).toBeTruthy();
   });
 
-  it('should return HttpSchemaManager from http object', () => {
+  it('should return HttpSchemaManager from http object with url property', () => {
     const factory = new SchemaManagerFactory(
       createTestingSchemaManagerHost({
         schema: {
@@ -70,5 +71,19 @@ describe(SchemaManagerFactory, () => {
     );
     const actual = factory.create();
     expect(actual instanceof FileSchemaManager).toBeTruthy();
+  });
+
+  it('should return ScriptedHttpSchemaManager from http object with fromScript property', () => {
+    const factory = new SchemaManagerFactory(
+      createTestingSchemaManagerHost({
+        schema: {
+          http: {
+            fromScript: 'graphql-config.js',
+          },
+        },
+      }),
+    );
+    const actual = factory.create();
+    expect(actual instanceof ScriptedHttpSchemaManager).toBeTruthy();
   });
 });

--- a/src/schema-manager/schema-manager-factory.ts
+++ b/src/schema-manager/schema-manager-factory.ts
@@ -64,13 +64,6 @@ export class SchemaManagerFactory {
           url: path,
         } as RequestSetup,
       };
-    }
-    if (/.js$/.test(path)) {
-      return {
-        http: {
-          fromScript: path,
-        },
-      } as ScriptedHttpSchemaManagerOptions;
     } else {
       return {
         file: {

--- a/src/schema-manager/scripted-http-schema-manager.test.ts
+++ b/src/schema-manager/scripted-http-schema-manager.test.ts
@@ -157,4 +157,25 @@ describe(ScriptedHttpSchemaManager, () => {
 
     expect(manager._getOptions()).rejects.toEqual(new Error('RequestSetup.url have to be valid url: some string'));
   });
+
+  it('should set method to POST if is not specified', async () => {
+    const requestSetup = {
+      url: 'http://example.com/graphql',
+      headers: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(requestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._host.fileExists.mockReturnValue(true);
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    const result = await manager._getOptions();
+
+    expect(result).toEqual({
+      ...requestSetup,
+      method: 'POST',
+    });
+  });
 });

--- a/src/schema-manager/scripted-http-schema-manager.test.ts
+++ b/src/schema-manager/scripted-http-schema-manager.test.ts
@@ -1,0 +1,160 @@
+import { ScriptedHttpSchemaManager } from './scripted-http-schema-manager';
+
+describe(ScriptedHttpSchemaManager, () => {
+  beforeEach(jest.resetModules);
+
+  function createScriptedHttpSchemaManager(fromScript: string = './graphql-config') {
+    const scriptedHttpSchemaManager = {
+      _host: {
+        getProjectRootPath: jest.fn(),
+        fileExists: jest.fn(),
+      },
+      _scriptFile: fromScript,
+      _options: null,
+      log: jest.fn(),
+      _requireScript: jest.fn(),
+      _getOptions: ScriptedHttpSchemaManager.prototype['_getOptions'],
+    };
+
+    scriptedHttpSchemaManager._getOptions = scriptedHttpSchemaManager._getOptions.bind(scriptedHttpSchemaManager);
+
+    return scriptedHttpSchemaManager;
+  }
+
+  it('should correctly load, execute http setup script, and return setup object', async () => {
+    const requestSetup = {
+      url: 'http://example.com/graphql',
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(requestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._host.fileExists.mockReturnValue(true);
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    const result = await manager._getOptions();
+
+    expect(result).toBe(requestSetup);
+  });
+
+  it('should return cached options if are available', async () => {
+    const requestSetup = {
+      url: 'http://example.com/graphql',
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(requestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._host.fileExists.mockReturnValue(true);
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    const initialized = await manager._getOptions(); // first call to initialize cache
+    const cached = await manager._getOptions(); // second call, should return cached value, should not call script again
+
+    expect(initialized).toBe(cached);
+    expect(configScriptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw error if configuration script file does not exist', () => {
+    const manager = createScriptedHttpSchemaManager('/file-that-does-not-exist.js');
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._host.fileExists.mockReturnValue(false);
+
+    expect(manager._getOptions()).rejects.toEqual(
+      new Error("ScriptedHttpSchemaManager configuration script 'file-that-does-not-exist.js' does not exist"),
+    );
+  });
+
+  it('should throw error if configuration script throws error', () => {
+    const configScriptMock = jest.fn().mockReturnValue(new Promise((_, reject) => reject(new Error('Some error'))));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.fileExists.mockReturnValue(true);
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    expect(manager._getOptions()).rejects.toEqual(
+      new Error(
+        `ScriptedHttpSchemaManager configuration script './graphql-config' execution failed due to: Error: Some error`,
+      ),
+    );
+  });
+
+  it('should throw error if request setup object does not contain url property', () => {
+    const wrongRequestSetup = {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(wrongRequestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.fileExists.mockReturnValue(true);
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    expect(manager._getOptions()).rejects.toEqual(
+      new Error(`RequestSetup object is wrong: ${JSON.stringify(wrongRequestSetup, null, 2)}`),
+    );
+  });
+
+  it('should throw error if request setup object does contain misspelled method property', () => {
+    const wrongRequestSetup = {
+      url: 'http://example.com/graphql',
+      methooood: 'POST',
+      headers: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(wrongRequestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.fileExists.mockReturnValue(true);
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    expect(manager._getOptions()).rejects.toEqual(
+      new Error(`RequestSetup object is wrong: ${JSON.stringify(wrongRequestSetup, null, 2)}`),
+    );
+  });
+
+  it('should throw error if request setup object does contain misspelled headers property', () => {
+    const wrongRequestSetup = {
+      url: 'http://example.com/graphql',
+      method: 'POST',
+      headddders: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(wrongRequestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.fileExists.mockReturnValue(true);
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    expect(manager._getOptions()).rejects.toEqual(
+      new Error(`RequestSetup object is wrong: ${JSON.stringify(wrongRequestSetup, null, 2)}`),
+    );
+  });
+
+  it('should throw error if request setup object url is not url', () => {
+    const wrongRequestSetup = {
+      url: 'some string',
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abcabcabc',
+      },
+    };
+    const configScriptMock = jest.fn().mockReturnValue(new Promise(resolve => resolve(wrongRequestSetup)));
+    const manager = createScriptedHttpSchemaManager();
+    manager._host.fileExists.mockReturnValue(true);
+    manager._host.getProjectRootPath.mockReturnValue('./');
+    manager._requireScript.mockReturnValue(configScriptMock);
+
+    expect(manager._getOptions()).rejects.toEqual(new Error('RequestSetup.url have to be valid url: some string'));
+  });
+});

--- a/src/schema-manager/scripted-http-schema-manager.ts
+++ b/src/schema-manager/scripted-http-schema-manager.ts
@@ -1,6 +1,6 @@
 import { SchemaManagerHost } from './types';
 import { RequestSetup, isRequestSetup } from './request-introspection-query';
-import { join } from 'path';
+import { join, isAbsolute } from 'path';
 import { HttpSchemaManager } from './http-schema-manager';
 
 interface ScriptedHttpSchemaManagerOptions {
@@ -17,7 +17,8 @@ export class ScriptedHttpSchemaManager extends HttpSchemaManager {
   }
 
   private _getScriptFilePath() {
-    return join(this._host.getProjectRootPath(), this._scriptFileName);
+    const rootPath = isAbsolute(this._host.getProjectRootPath()) ? this._host.getProjectRootPath() : process.cwd();
+    return join(rootPath, this._scriptFileName);
   }
 
   private _requireScript(path: string) {

--- a/src/schema-manager/scripted-http-schema-manager.ts
+++ b/src/schema-manager/scripted-http-schema-manager.ts
@@ -1,0 +1,63 @@
+import { SchemaManagerHost } from './types';
+import { RequestSetup, isRequestSetup } from './request-introspection-query';
+import { join } from 'path';
+import { HttpSchemaManager } from './http-schema-manager';
+
+interface ScriptedHttpSchemaManagerOptions {
+  fromScript: string;
+}
+
+export class ScriptedHttpSchemaManager extends HttpSchemaManager {
+  private _scriptFile: string;
+
+  constructor(_host: SchemaManagerHost, options: ScriptedHttpSchemaManagerOptions) {
+    super(_host);
+    this._scriptFile = options.fromScript;
+  }
+
+  private _requireScript(path: string) {
+    return require(path);
+  }
+
+  protected async _getOptions(): Promise<RequestSetup> {
+    if (this._options !== null) {
+      return this._options;
+    }
+
+    const configurationScriptPath = join(this._host.getProjectRootPath(), this._scriptFile);
+
+    if (!this._host.fileExists(configurationScriptPath)) {
+      const errorMessage = `ScriptedHttpSchemaManager configuration script '${configurationScriptPath}' does not exist`;
+      this.log(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const configurationScript = this._requireScript(configurationScriptPath);
+
+    let setup = null;
+
+    try {
+      setup = await configurationScript(this._host.getProjectRootPath());
+    } catch (error) {
+      const errorMessage =
+        `ScriptedHttpSchemaManager configuration script '${this._scriptFile}' ` + `execution failed due to: ${error}`;
+      this.log(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    if (!isRequestSetup(setup)) {
+      const errorMessage = `RequestSetup object is wrong: ${JSON.stringify(setup, null, 2)}`;
+      this.log(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    if (!/https?:/.test(setup.url)) {
+      const errorMessage = `RequestSetup.url have to be valid url: ${setup.url}`;
+      this.log(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    this._options = setup;
+    return setup;
+  }
+}

--- a/src/schema-manager/scripted-http-schema-manager.ts
+++ b/src/schema-manager/scripted-http-schema-manager.ts
@@ -39,8 +39,7 @@ export class ScriptedHttpSchemaManager extends HttpSchemaManager {
     try {
       setup = await configurationScript(this._host.getProjectRootPath());
     } catch (error) {
-      const errorMessage =
-        `ScriptedHttpSchemaManager configuration script '${this._scriptFile}' ` + `execution failed due to: ${error}`;
+      const errorMessage = `ScriptedHttpSchemaManager configuration script '${this._scriptFile}' execution failed due to: ${error}`;
       this.log(errorMessage);
       throw new Error(errorMessage);
     }

--- a/src/schema-manager/scripted-http-schema-manager.ts
+++ b/src/schema-manager/scripted-http-schema-manager.ts
@@ -56,6 +56,7 @@ export class ScriptedHttpSchemaManager extends HttpSchemaManager {
       throw new Error(errorMessage);
     }
 
+    setup.method = setup.method || 'POST';
     this._options = setup;
     return setup;
   }

--- a/src/schema-manager/types.ts
+++ b/src/schema-manager/types.ts
@@ -9,7 +9,13 @@ export type SchemaConfig = {
     | {
         http: {
           url: string;
+          method?: string;
           headers?: { [key: string]: string };
+        };
+      }
+    | {
+        http: {
+          fromScript: string;
         };
       };
   localSchemaExtensions?: string[];


### PR DESCRIPTION
Hello! At first I would like to point out that I am new to graphql and I didn't really use your plugin yet, I just successfully tested if it works.

I have added some feature that I think was missing.

`ScriptedHttpSchemaManager` allows to use `HttpSchemaManager` with config built by javascript. This can be useful if the connections are authorized with a token that expires after some time or when everyone who wants to use our backend locally has to manually set their own randomly generated token, which we do not want to push to github repository.

I was thinking about environment variables, but we would need to update environment variables or run some script that does it for us every time when our authorization token expires.

If there is something that I should change, then let me know - I will fix that, otherwise I would be really happy to be able to do `npm i -D ts-graphql-plugin` and use it with my `graphql-config.js` file in my future projects.

PS. Please check if I did not break anything. There was few tests that were not working out of the box, including few snapshots (I work on windows, slashes are reversed comparing to linux). Also, for testing I had to `npm run compile` and then copy `lib` folder to my second project into `./node_modules/ts-graphql-plugin/lib` because it didn't work when I was trying to `npm link` and then `npm link ts-graphql-plugin`. Changed plugin was logging everything fine and was executing script, but code completion was just not working, I don't know why.

