### PR TITLE
Allow typescript v4 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^14.0.0",
-    "typescript": "^2.3.0 || ^3.0.0"
+    "typescript": "^2.3.0 || ^3.0.0 || ^4.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Prevents warning from yarn.