### PR TITLE
docs(CUSTOMIZE_TYPE_GEN.md): fix identifier typo

### DIFF
--- a/docs/CUSTOMIZE_TYPE_GEN.md
+++ b/docs/CUSTOMIZE_TYPE_GEN.md
@@ -235,7 +235,7 @@ const addonFactory: TypeGenAddonFactory = ctx => {
         ts.factory.createTypeAliasDeclaration(
           undefined,
           [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
-          ts.factory.createIdentifier(`Wrapts${ResultNode.name.text}`),
+          ts.factory.createIdentifier(`Wrap${tsResultNode.name.text}`),
           undefined,
           ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('AwesomeType'), [
             ts.factory.createTypeReferenceNode(ts.factory.createIdentifier(tsResultNode.name.text), undefined),


### PR DESCRIPTION
Hi ! :wave:

Just a little typo I found while following the docs, thanks for the nice library 🙏🏻 