### PR TITLE
Changed default method to post

### DIFF
--- a/src/schema-manager/request-introspection-query.ts
+++ b/src/schema-manager/request-introspection-query.ts
@@ -38,7 +38,7 @@ export function requestIntrospectionQuery(options: RequestSetup) {
   return new Promise<GraphQLSchema>((resolve, reject) => {
     const uri = parse(options.url);
 
-    const { method } = options;
+    const { method = 'POST' } = options;
     const { hostname, protocol, path } = uri;
     const port = uri.port && Number.parseInt(uri.port, 10);
     const reqParam = { hostname, protocol, path, port, headers, method };


### PR DESCRIPTION
Changes the default method to `POST` so that calling fetching a schema will actually work. 
Without this change simply trying to fetch the schema with this config :
```json
"schema": {
    "http": {
      "url": "https://rickandmortyapi.com/graphql"                  
    }
  }     
```

Will fail because you can't write to the request stream of a `GET` request.