### PR TITLE
fix: support Typescript v4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ts-jest": "27.0.7",
     "ts-loader": "9.2.6",
     "ts-node": "10.4.0",
-    "typescript": "4.4.4",
+    "typescript": "4.5.2",
     "typescript-eslint-language-service": "4.1.5",
     "vscode-languageserver-types": "3.16.0",
     "webpack": "5.64.1",

--- a/project-fixtures/gql-errors-prj/package.json
+++ b/project-fixtures/gql-errors-prj/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "graphql": "15.7.2",
     "ts-graphql-plugin": "file:../../",
-    "typescript": "4.4.4"
+    "typescript": "4.5.2"
   }
 }

--- a/project-fixtures/gql-errors-prj/yarn.lock
+++ b/project-fixtures/gql-errors-prj/yarn.lock
@@ -40,10 +40,10 @@ graphql@15.7.2:
     graphql-language-service-interface "^2.4.1"
     graphql-language-service-types "^1.6.1"
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 vscode-languageserver-types@^3.15.1:
   version "3.15.1"

--- a/project-fixtures/react-apollo-prj/package.json
+++ b/project-fixtures/react-apollo-prj/package.json
@@ -10,6 +10,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "subscriptions-transport-ws": "0.11.0",
-    "typescript": "4.4.4"
+    "typescript": "4.5.2"
   }
 }

--- a/project-fixtures/react-apollo-prj/yarn.lock
+++ b/project-fixtures/react-apollo-prj/yarn.lock
@@ -231,10 +231,10 @@ tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 "ws@^5.2.0 || ^6.0.0 || ^7.0.0":
   version "7.4.6"

--- a/src/ts-ast-util/output-source.ts
+++ b/src/ts-ast-util/output-source.ts
@@ -2,7 +2,11 @@ import path from 'path';
 import ts from 'typescript';
 
 import { OutputSource } from './types';
-import { isImportDeclarationWithCondition, mergeImportDeclarationsWithSameModules } from './utilily-functions';
+import {
+  createImportSpecifier,
+  isImportDeclarationWithCondition,
+  mergeImportDeclarationsWithSameModules,
+} from './utilily-functions';
 
 const printer = ts.createPrinter();
 
@@ -31,7 +35,7 @@ export class DefaultOutputSource implements OutputSource {
 
   pushNamedImportIfNeeded(identifierName: string, from: string) {
     if (this.findImportDeclarationIndex({ name: identifierName, from }) !== -1) return false;
-    const importSpecifier = ts.createImportSpecifier(undefined, ts.createIdentifier(identifierName));
+    const importSpecifier = createImportSpecifier(false, undefined, ts.createIdentifier(identifierName));
     const namedBinding = ts.createNamedImports([importSpecifier]);
     const importClause = ts.createImportClause(undefined, namedBinding);
     const moduleSpecifier = ts.createStringLiteral(from);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5581,10 +5581,10 @@ typescript-eslint-language-service@4.1.5:
   resolved "https://registry.yarnpkg.com/typescript-eslint-language-service/-/typescript-eslint-language-service-4.1.5.tgz#8c4e66e3d742b520f2abb7d1d8e953d9fa1bf8b4"
   integrity sha512-lJ9tH53m8e8fYYwhG5hTpiUHCz4SjY55rT8T4ADrmF/29JPdWkUik8cbZy+KsCsUIG1CEMRz+DOV4S+wVyYivQ==
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Hi! I noticed that Typescript v4.5 made some breaking changes to the compiler API. I wanted to help to make ts-graphql-plugin compatible in case that is helpful. This is a work-in-progress - I think what I have done so far fixes code generation, but there is still a failing test in the completions spec.

In version 4.5 Typescript added support for [assertion clauses](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#import-assertions) on import statements, and for [type modifiers](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names) on import names. As a result the signatures for `ts.createImportSpecifier` and `ts.updateImportDeclaration` changed.

`ts.updateImportDeclaration` got a new argument at the end of its arguments list to specify an assertion clause. For some reason this is a required argument. But it can be `undefined` if there is no assert clause, so I made changes to put `undefined` in that position.

`ts.createImportSpecifier` got a new boolean argument to indicate whether the import is type-only. Unfortunately this was added as the first argument. I wanted to try to keep compatibility with previous Typescript versions, so I put in a check that calls `ts.createImportSpecifier` differently depending on the Typescript version.