### PR TITLE
Fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,16 +5,22 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
----**Describe the bug**
+---
+
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Debug log**
+### Debug log
+
 If applicable, add screenshots to help explain your problem.
 
 If the bug occurs on editor/IDE, turn on verbose log with the following and paste tssserver.log of from the replay.
@@ -25,5 +31,6 @@ $ export TSS_LOG="-file `pwd`/tsserver.log -level verbose"
 
 If the bug occurs on CLI, paste log with `--verbose` option.
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.


### PR DESCRIPTION
The "front matter" of the template is broken because a line break is missing.

This PR restores the front matter and improves the formatting