### PR TITLE
feat: Resolve interpolation referring call expression

### DIFF
--- a/src/ts-ast-util/__snapshots__/template-expression-resolver.test.ts.snap
+++ b/src/ts-ast-util/__snapshots__/template-expression-resolver.test.ts.snap
@@ -68,3 +68,20 @@ exports[`resolve string combinination pattern should return combined string with
                   ...Foo
                 }"
 `;
+
+exports[`resolve string combinination pattern should return combined string with template in call expression 1`] = `
+"
+                
+                
+                fragment Foo on Hoge {
+                  name
+                }
+              
+                fragment Piyo on Hoge {
+                  ...Foo
+                }
+              
+                query {
+                  ...Piyo
+                }"
+`;

--- a/src/ts-ast-util/template-expression-resolver.ts
+++ b/src/ts-ast-util/template-expression-resolver.ts
@@ -371,6 +371,13 @@ export class TemplateExpressionResolver {
       } else {
         return setValueToCache(getValueForTemplateExpression(node.template, dependencies));
       }
+    } else if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.arguments.length > 0) {
+      const firstArgNode = node.arguments[0];
+      if (ts.isNoSubstitutionTemplateLiteral(firstArgNode)) {
+        return setValueToCache({ text: firstArgNode.text, dependencies });
+      } else if (ts.isTemplateExpression(firstArgNode)) {
+        return setValueToCache(getValueForTemplateExpression(firstArgNode, dependencies));
+      }
     } else if (ts.isTemplateExpression(node)) {
       return setValueToCache(getValueForTemplateExpression(node, dependencies));
     }


### PR DESCRIPTION
## What

Make TemplateExpressionResolver resolve referring CallExpression pattern:

```ts
const f1 = gql(`fragment F1 on Hoge { __typename }`)

const f2 = gql(`${f1} fragment F2 on Hoge { ...F1 }`)
```